### PR TITLE
Fixed exporter progress report compilation error with MSVC

### DIFF
--- a/src/ctrl/Exporter.cpp
+++ b/src/ctrl/Exporter.cpp
@@ -455,53 +455,25 @@ Exporter::Result Exporter::execute()
         if (mProgressReporter)
         {
             mProgressReporter->setProgress((int)(100 * mProgress));
+            QString sectionName = "";
             if (98.5f <= (float)100*mProgress){
-                QString sectionName = QCoreApplication::translate("Exporter", "Finishing up");
-                switch (mTick){
-                    case 0 ... 4: sectionName = sectionName + ".";
-                                  mTick+=1;
-                                  break;
-
-                    case 5 ... 9: sectionName = sectionName + "..";
-                                  mTick+=1;
-                                  break;
-
-                    case 10 ... 14: sectionName = sectionName + "...";
-                                    mTick+=1;
-                                    break;
-
-                    case 15 ... 18: mTick+=1;
-                                    break;
-
-                    case 19 : mTick=0;
-                              break;
-                }
-              mProgressReporter->setSection(sectionName);
+                sectionName = QCoreApplication::translate("Exporter", "Finishing up");
             }
             else
-                {
-                QString sectionName = QCoreApplication::translate("Exporter", "Rendering");
-                switch (mTick){
-                    case 0 ... 4: sectionName = sectionName + ".";
-                                  mTick+=1;
-                                  break;
-
-                    case 5 ... 9: sectionName = sectionName + "..";
-                                  mTick+=1;
-                                  break;
-
-                    case 10 ... 14: sectionName = sectionName + "...";
-                                    mTick+=1;
-                                    break;
-
-                    case 15 ... 18: mTick+=1;
-                                    break;
-
-                    case 19 : mTick=0;
-                              break;
-                }
-              mProgressReporter->setSection(sectionName);
+            {
+                sectionName = QCoreApplication::translate("Exporter", "Rendering");
             }
+
+            int tickRate = 4;
+            sectionName += QStringLiteral(".").repeated(qFloor(mTick / tickRate) + 1);
+
+            mTick += 1;
+            if (mTick >= 3 * tickRate)
+            {
+                mTick = 0;
+            }
+
+            mProgressReporter->setSection(sectionName);
 
             if (mProgressReporter->wasCanceled())
             {


### PR DESCRIPTION
Previously, the exporter progress report was causing a compilation error with MSVC due to the use of a range switch case statement, which is unsupported on non-GNU compilers.