### PR TITLE
Use OpenGL 3.3 instead of 3.1 on macOS

### DIFF
--- a/src/gl/Global.cpp
+++ b/src/gl/Global.cpp
@@ -98,4 +98,8 @@ void Global::doneCurrent()
 
 } // namespace gl
 
-const QPair<int, int> gl::Global::kVersion{ 3, 1 };
+#if defined (Q_OS_MACOS)
+    const QPair<int, int> gl::Global::kVersion{ 3, 3 };
+#else
+    const QPair<int, int> gl::Global::kVersion{ 3, 1 };
+#endif

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -64,11 +64,11 @@ MainWindow::MainWindow(ctrl::System& aSystem, GUIResources& aResources, const Lo
     {
         QSurfaceFormat format;
 #if defined(USE_GL_CORE_PROFILE)
-    format.setVersion(gl::Global::kVersion.first, gl::Global::kVersion.second);
+        format.setVersion(gl::Global::kVersion.first, gl::Global::kVersion.second);
 #if defined (Q_OS_MACOS)
-    format.setProfile(QSurfaceFormat::CoreProfile);
+        format.setProfile(QSurfaceFormat::CoreProfile);
 #else
-    format.setProfile(QSurfaceFormat::NoProfile);
+        format.setProfile(QSurfaceFormat::NoProfile);
 #endif
 #endif
         format.setSamples(4);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -64,8 +64,12 @@ MainWindow::MainWindow(ctrl::System& aSystem, GUIResources& aResources, const Lo
     {
         QSurfaceFormat format;
 #if defined(USE_GL_CORE_PROFILE)
-        format.setVersion(gl::Global::kVersion.first, gl::Global::kVersion.second);
-        format.setProfile(QSurfaceFormat::NoProfile);
+    format.setVersion(gl::Global::kVersion.first, gl::Global::kVersion.second);
+#if defined (Q_OS_MACOS)
+    format.setProfile(QSurfaceFormat::CoreProfile);
+#else
+    format.setProfile(QSurfaceFormat::NoProfile);
+#endif
 #endif
         format.setSamples(4);
         QSurfaceFormat::setDefaultFormat(format);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -65,11 +65,11 @@ MainWindow::MainWindow(ctrl::System& aSystem, GUIResources& aResources, const Lo
         QSurfaceFormat format;
 #if defined(USE_GL_CORE_PROFILE)
         format.setVersion(gl::Global::kVersion.first, gl::Global::kVersion.second);
-#if defined (Q_OS_MACOS)
+    #if defined (Q_OS_MACOS)
         format.setProfile(QSurfaceFormat::CoreProfile);
-#else
+    #else
         format.setProfile(QSurfaceFormat::NoProfile);
-#endif
+    #endif
 #endif
         format.setSamples(4);
         QSurfaceFormat::setDefaultFormat(format);


### PR DESCRIPTION
Revert the switch from OpenGL 3.3 to OpenGL 3.1 on macOS. A driver bug on some macOS devices doesn't allow animeeffects to initialize an OpenGL 3.1 context.