### PR TITLE
Change HSV key value range for backwards compatibility

### DIFF
--- a/src/core/HSVKey.cpp
+++ b/src/core/HSVKey.cpp
@@ -2,19 +2,9 @@
 
 namespace core {
 
-HSVKey::Data::Data(): mEasing(), mHue(0), mSaturation(0), mValue(0), mAbsolute(0), mHSV{0, 0, 0, 0} {}
+HSVKey::Data::Data(): mEasing(), mHue(0), mSaturation(100), mValue(100), mAbsolute(0), mHSV{0, 100, 100, 0} {}
 
 bool HSVKey::Data::isZero() const { return mHSV == QList<int>{0, 0, 0, 0}; }
-
-void HSVKey::Data::clamp(const QString& type) {
-    if (type == "hue" || type.isEmpty()) {
-        mHue = util::MathUtil::getClamp(mHue, 0, 360);
-    } else if (type == "sat" || type.isEmpty()) {
-        mSaturation = util::MathUtil::getClamp(mSaturation, -100, 100);
-    } else if (type == "val" || type.isEmpty()) {
-        mValue = util::MathUtil::getClamp(mValue, -100, 100);
-    }
-}
 
 HSVKey::HSVKey(): mData() {}
 

--- a/src/core/HsvKey.h
+++ b/src/core/HsvKey.h
@@ -16,7 +16,6 @@ public:
         int mValue;
         int mAbsolute;
         QList<int> mHSV;
-        void clamp(const QString& type);
 
     public:
         Data();
@@ -26,17 +25,14 @@ public:
 
         void setHue(int aHue) {
             mHue = aHue;
-            clamp("hue");
             updateHSV();
         }
         void setSaturation(int aSaturation) {
             mSaturation = aSaturation;
-            clamp("sat");
             updateHSV();
         }
         void setValue(int aValue) {
             mValue = aValue;
-            clamp("val");
             updateHSV();
         }
         void setAbsolute(int aAbsolute) {
@@ -48,7 +44,6 @@ public:
             mSaturation = aHSV[1];
             mValue = aHSV[2];
             mAbsolute = aHSV[3];
-            clamp("");
             updateHSV();
         }
         void updateHSV() {

--- a/src/core/LayerNode.cpp
+++ b/src/core/LayerNode.cpp
@@ -464,8 +464,8 @@ void LayerNode::renderHSV(const RenderInfo& aInfo, const TimeCacheAccessor& aAcc
         shader.setUniformValue("setColor", bool(HSVData[3]));
 
         float hue = (float)HSVData[0] / 360.0f;
-        float saturation = (float)(HSVData[1]) / 100.0f + 1.0f;
-        float value = (float)(HSVData[2]) / 100.0f + 1.0f;
+        float saturation = (float)(HSVData[1]) / 100.0f;
+        float value = (float)(HSVData[2]) / 100.0f;
 
         shader.setUniformValue("hue", hue);
         shader.setUniformValue("saturation", saturation);

--- a/src/gui/prop/prop_CurrentKeyPanel.cpp
+++ b/src/gui/prop/prop_CurrentKeyPanel.cpp
@@ -333,13 +333,13 @@ namespace prop {
 
             // saturation
             mSaturation = new IntegerItem(this);
-            mSaturation->setRange(-100, 100);
+            mSaturation->setRange(0, 200);
             mSaturation->box().setSingleStep(1);
             mSaturation->onValueUpdated = [=](int, int aNext) { this->mAccessor.assignHSV(aNext, "sat"); };
 
             // value
             mValue = new IntegerItem(this);
-            mValue->setRange(-100, 100);
+            mValue->setRange(0, 200);
             mValue->box().setSingleStep(1);
             mValue->onValueUpdated = [=](int, int aNext) { this->mAccessor.assignHSV(aNext, "val"); };
 


### PR DESCRIPTION
Change HSV key saturation and value range from [-100; 100] to [0; 200] for backwards compatibility.