### PR TITLE
Fix inconsistent scroll size

### DIFF
--- a/src/gui/ObjectTreeWidget.cpp
+++ b/src/gui/ObjectTreeWidget.cpp
@@ -106,6 +106,10 @@ ObjectTreeWidget::ObjectTreeWidget(ViaPoint& aViaPoint, GUIResources& aResources
         mDeleteAction = new QAction(tr("Delete"), this);
         mDeleteAction->connect(mDeleteAction, &QAction::triggered, this, &ObjectTreeWidget::onDeleteActionTriggered);
     }
+
+    // enable pixel scrolling
+    QTreeWidget::setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
+    QTreeWidget::verticalScrollBar()->setSingleStep(24);
 }
 
 void ObjectTreeWidget::setProject(core::Project* aProject) {


### PR DESCRIPTION
By default Qt scrolls by elements, not by pixels, which causes issues with layers that have many keyframes. This commit switches to scrolling per pixel, 24 pixels at a time.